### PR TITLE
This PR add support for Rails 4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ bin/
 .ruby-version
 .ruby-gemset
 gemfiles/*.lock
+*.swp
+*.un~

--- a/postgres_ext-serializers.gemspec
+++ b/postgres_ext-serializers.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'actionpack', '~> 4.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'
-  spec.add_development_dependency 'm'
   spec.add_development_dependency 'bourne', '~> 1.3.0'
   spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'dotenv'

--- a/test/sideloading_test.rb
+++ b/test/sideloading_test.rb
@@ -20,9 +20,10 @@ describe 'ArraySerializer patch' do
     end
 
     it 'does not instantiate ruby objects for relations' do
-      relation.stubs(:to_a).returns([])
-      json_data
-      assert_received(relation, :to_a) { |expect| expect.never}
+      relation.stub(:to_a,
+                    -> { raise Exception.new('#to_a should never be called') }) do
+        json_data
+      end
     end
   end
 
@@ -44,9 +45,10 @@ describe 'ArraySerializer patch' do
     end
 
     it 'does not instantiate ruby objects for relations' do
-      relation.stubs(:to_a).returns([])
-      json_data
-      assert_received(relation, :to_a) { |expect| expect.never}
+      relation.stub(:to_a,
+                    -> { raise Exception.new('#to_a should never be called') }) do
+        json_data
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,5 @@
 require 'active_record'
 require 'minitest/autorun'
-require 'mocha/setup'
 require 'bourne'
 require 'database_cleaner'
 require 'postgres_ext/serializers'
@@ -11,7 +10,7 @@ end
 require 'dotenv'
 Dotenv.load
 
-ActiveRecord::Base.establish_connection
+ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
 
 class TestController < ActionController::Base
   def url_options
@@ -65,7 +64,7 @@ end
 
 DatabaseCleaner.strategy = :deletion
 
-class MiniTest::Spec
+class Minitest::Spec
   class << self
     alias :context :describe
   end


### PR DESCRIPTION
# 

Bump Rails version to 4.1
Removes mocha and uses Minitest for stubing
# Uses latest version of postgres_ext gem from branch rails4.1

Some changes seems to be incompatible with Rails 4.1 probably there is a work around to have support for both versions.

This branch depends on branch rails4.1. from postgres_ext all tests pass also I have a project where I'm using both gems from Github and everything works just fine.
