### PR TITLE
Generate sql fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # CHANGELOG
 
+## 0.0.4 - 2014-12-13
+
+### Added
+- Nothing.
+
+### Deprecated
+- Class methods on serializers for computed properties have been deprecated,
+  these should now be instance methods and alias like `current_user` can now
+  be used so no longer has `scope` argument. Sql computed properties on models
+  are still class methods.
+
+### Removed
+- Nothing.
+
+### Fixed
+- Fixed generation of SQL for github issues #18 and #20
+- Returns `[]` instead of `null` if data empty, required by frameworks like ember
+- Use postgres `json_agg` function if available
+- Fixed relation "" does not exist error
+
 ## 0.0.3 - 2014-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,23 +48,37 @@ discover a SQL version of this call by looking for a class method with
 the same name and the prefex `__sql`. Here's an example:
 
 ```ruby
+class MyModel < ActiveRecord::Base
+  def full_name
+    "#{object.first_name} #{object.last_name}"
+  end
+
+  def self.full_name__sql
+    "first_name || ' ' || last_name"
+  end
+end
+
 class MySerializer < ActiveModel::Serializer
   def full_name
     "#{object.first_name} #{object.last_name}"
   end
 
-  def self.full_name__sql(scope)
+  def full_name__sql
     "first_name || ' ' || last_name"
   end
 end
 ```
 
-The scope is passed to methods in a serializer, while there are no
-arguments passed to `__sql` methods in a model. You will not have access
-to the `current_user` alias of `scope`, but the scope passed in will be
-the same object. Right now, this string is used as a SQL literal, so be
-sure to *not* use untrusted values in the return value. This feature may
-change before the 1.0 release, if a cleaner implementation is found.
+There is no instance of MyModel created so sql computed properties needs to be
+a class method. Right now, this string is used as a SQL literal, so be sure to
+*not* use untrusted values in the return value.
+
+### Note: Postgres date, timestamp or timestamptz format
+Postgres 9.2 and 9.3 by default renders dates according to the current DateStyle
+Postgres setting, but many JSON processors require dates to be in ISO 8601
+format e.g. Firefox or Internet Explorer will parse string as invalid date with
+default DateStyle setting. Postgres 9.4 onwards now uses ISO 8601 for JSON
+serialization instead.
 
 ## Developing
 

--- a/Rakefile
+++ b/Rakefile
@@ -83,6 +83,19 @@ namespace :db do
       t.datetime "updated_at"
     end
 
+    ActiveRecord::Base.connection.create_table :offers, force: true do |t|
+      t.integer  "created_by_id"
+      t.integer  "reviewed_by_id"
+      t.datetime "created_at"
+      t.datetime "updated_at"
+    end
+
+    ActiveRecord::Base.connection.create_table :users, force: true do |t|
+      t.string   "name"
+      t.datetime "created_at"
+      t.datetime "updated_at"
+    end
+
     puts 'Database migrated'
   end
 end

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -15,7 +15,7 @@ describe 'ArraySerializer patch' do
     end
 
     it 'generates the proper json output' do
-      json_expected = %{{"tags":[{"id":#{@tag.id},"name":"My tag"}],"notes":[{"id":#{@note.id},"name":"Title","tag_ids":[#{@tag.id}]}]}}
+      json_expected = %{{"notes":[{"id":#{@note.id},"name":"Title","tag_ids":[#{@tag.id}]}],"tags":[{"id":#{@tag.id},"name":"My tag"}]}}
       json_data.must_equal json_expected
     end
   end

--- a/test/sideloading_test.rb
+++ b/test/sideloading_test.rb
@@ -1,6 +1,7 @@
 
 describe 'ArraySerializer patch' do
-  let(:json_data)  { ActiveModel::Serializer.build_json(controller, relation, {}).to_json }
+  let(:json_data)  { ActiveModel::Serializer.build_json(controller, relation, options).to_json }
+  let(:options)    { }
 
   context 'no where clause on root relation' do
     let(:relation)   { Note.all }
@@ -12,7 +13,7 @@ describe 'ArraySerializer patch' do
 
       tag    = Tag.create name: 'tag 1', note_id: note_1.id
       Tag.create name: 'tag 2'
-      @json_expected = "{\"tags\":[{\"id\":#{tag.id},\"name\":\"tag 1\",\"note_id\":#{note_1.id}}],\"notes\":[{\"id\":#{note_1.id},\"content\":\"dummy content\",\"name\":\"test\",\"tag_ids\":[#{tag.id}]},{\"id\":#{note_2.id},\"content\":\"dummy content\",\"name\":\"test 2\",\"tag_ids\":[]}]}"
+      @json_expected = "{\"notes\":[{\"id\":#{note_1.id},\"content\":\"dummy content\",\"name\":\"test\",\"tag_ids\":[#{tag.id}]}, \n {\"id\":#{note_2.id},\"content\":\"dummy content\",\"name\":\"test 2\",\"tag_ids\":[]}],\"tags\":[{\"id\":#{tag.id},\"name\":\"tag 1\",\"note_id\":#{note_1.id}}]}"
     end
 
     it 'generates the proper json output for the serializer' do
@@ -37,7 +38,7 @@ describe 'ArraySerializer patch' do
 
       tag    = Tag.create name: 'tag 1', note_id: note_1.id
       Tag.create name: 'tag 2', note_id: note_2.id
-      @json_expected = "{\"tags\":[{\"id\":#{tag.id},\"name\":\"tag 1\",\"note_id\":#{note_1.id}}],\"notes\":[{\"id\":#{note_1.id},\"content\":\"dummy content\",\"name\":\"test\",\"tag_ids\":[#{tag.id}]}]}"
+      @json_expected = "{\"notes\":[{\"id\":#{note_1.id},\"content\":\"dummy content\",\"name\":\"test\",\"tag_ids\":[#{tag.id}]}],\"tags\":[{\"id\":#{tag.id},\"name\":\"tag 1\",\"note_id\":#{note_1.id}}]}"
     end
 
     it 'generates the proper json output for the serializer' do
@@ -45,6 +46,97 @@ describe 'ArraySerializer patch' do
     end
 
     it 'does not instantiate ruby objects for relations' do
+      relation.stub(:to_a,
+                    -> { raise Exception.new('#to_a should never be called') }) do
+        json_data
+      end
+    end
+  end
+
+  context 'root relation has belongs_to association' do
+    let(:relation)   { Tag.all }
+    let(:controller) { TagController.new }
+    let(:options)    { { each_serializer: TagWithNoteSerializer } }
+
+    before do
+      note = Note.create content: 'Test', name: 'Title'
+      tag = Tag.create name: 'My tag', note: note
+      @json_expected = "{\"tags\":[{\"id\":#{tag.id},\"name\":\"My tag\",\"note_id\":#{note.id}}],\"notes\":[{\"id\":#{note.id},\"content\":\"Test\",\"name\":\"Title\",\"tag_ids\":[#{tag.id}]}]}"
+    end
+
+    it 'generates the proper json output for the serializer' do
+      json_data.must_equal @json_expected
+    end
+
+    it 'does not instantiate ruby objects for relations' do
+      relation.stub(:to_a,
+                    -> { raise Exception.new('#to_a should never be called') }) do
+        json_data
+      end
+    end
+  end
+
+  context 'relation has multiple associates to the same table' do
+    let(:relation)   { User.all }
+    let(:controller) { UserController.new }
+
+    before do
+      user = User.create name: 'John'
+      reviewer = User.create name: 'Peter'
+      offer = Offer.create created_by: user, reviewed_by: reviewer
+      @json_expected = "{\"users\":[{\"id\":#{reviewer.id},\"name\":\"Peter\",\"offer_ids\":[],\"reviewed_offer_ids\":[#{offer.id}]}, \n {\"id\":#{user.id},\"name\":\"John\",\"offer_ids\":[#{offer.id}],\"reviewed_offer_ids\":[]}],\"offers\":[{\"id\":#{offer.id}}]}"
+    end
+
+    it 'generates the proper json output for the serializer' do
+      json_data.must_equal @json_expected
+    end
+
+    it 'does not instantiate ruby objects for relations' do
+      relation.stub(:to_a,
+                    -> { raise Exception.new('#to_a should never be called') }) do
+        json_data
+      end
+    end
+  end
+
+  context 'empty data should return empty array not null' do
+    let(:relation)   { Tag.all }
+    let(:controller) { TagController.new }
+    let(:options)    { { each_serializer: TagWithNoteSerializer } }
+
+    before do
+      @json_expected = "{\"tags\":[],\"notes\":[]}"
+    end
+
+    it 'generates the proper json output for the serializer' do
+      json_data.must_equal @json_expected
+    end
+
+    it 'does not instantiate ruby objects for relations' do
+      relation.stub(:to_a,
+                    -> { raise Exception.new('#to_a should never be called') }) do
+        json_data
+      end
+    end
+  end
+
+  context 'nested filtering support' do
+    let(:relation)   { Tag.where(note: { name: 'Title' }) }
+    let(:controller) { TagController.new }
+
+    before do
+      note = Note.create content: 'Test', name: 'Title'
+      tag = Tag.create name: 'My tag', note: note
+      @json_expected = ""
+    end
+
+    it 'generates the proper json output for the serializer' do
+      skip('to be fixed')
+      json_data.must_equal @json_expected
+    end
+
+    it 'does not instantiate ruby objects for relations' do
+      skip('to be fixed')
       relation.stub(:to_a,
                     -> { raise Exception.new('#to_a should never be called') }) do
         json_data

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,8 +29,8 @@ class PeopleController < TestController; end
 class PersonSerializer < ActiveModel::Serializer
   attributes :id, :full_name, :attendance_name
 
-  def self.attendance_name__sql(scope)
-    if scope &&  scope[:admin]
+  def attendance_name__sql
+    if current_user && current_user[:admin]
       "'ADMIN ' || last_name || ', ' || first_name"
     else
       "last_name || ', ' || first_name"
@@ -63,12 +63,42 @@ class Tag < ActiveRecord::Base
   belongs_to :note
 end
 
+class TagController < TestController; end
+
 class TagSerializer < ActiveModel::Serializer
   attributes :id, :name
   embed :ids
   has_one :note
 end
 
+class TagWithNoteSerializer < ActiveModel::Serializer
+  attributes :id, :name
+  embed :ids, include: true
+  has_one :note
+end
+
+class User < ActiveRecord::Base
+  has_many :offers, foreign_key: :created_by_id, inverse_of: :created_by
+  has_many :reviewed_offers, foreign_key: :reviewed_by_id, inverse_of: :reviewed_by, class_name: 'Offer'
+end
+
+class Offer < ActiveRecord::Base
+  belongs_to :created_by, class_name: 'User', inverse_of: :offers
+  belongs_to :reviewed_by, class_name: 'User', inverse_of: :reviewed_offers
+end
+
+class UserController < TestController; end
+
+class OfferSerializer < ActiveModel::Serializer
+  attributes :id
+end
+
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :name
+  embed :ids, include: true
+  has_many :offers, serializer: OfferSerializer
+  has_many :reviewed_offers, serializer: OfferSerializer
+end
 
 DatabaseCleaner.strategy = :deletion
 


### PR DESCRIPTION
# Fixes issues #10, #19, #18, #20 and #22
## Issue #20

Issue was fixed by generating CTE for root relation first (instead of later) and then using that to filter child ids table i.e.

``` sql
WITH tags_attributes_filter AS 
( 
       SELECT "tags"."id", 
              "tags"."name", 
              "tags"."note_id" 
       FROM "tags"
),
...
WITH notes_ids AS 
( 
       SELECT "notes"."id" 
       FROM   "notes" 
       WHERE  "notes"."id" IN ( SELECT "tags_attributes_filter"."note_id" FROM "tags_attributes_filter")
),
```

Instead of

``` sql
WITH notes_ids AS 
( 
       SELECT "notes"."id" 
       FROM   "notes" 
       WHERE  "notes"."note_id" IN ( SELECT "tags_ids"."id" FROM "tags_ids")
),
...
WITH tags_attributes_filter AS 
( 
       SELECT "tags"."id", 
              "tags"."name", 
              "tags"."note_id" 
       FROM "tags"
),
```
## Issue #18

Issue was fixed by adding foreign key name to CTE name to make it unique and then combining them together with `UNION` before passing to JSON function i.e.

``` sql
offers_created_by_id_attributes_filter AS
( 
    SELECT "offers"."id" 
    FROM   "offers" 
    WHERE  "offers"."created_by_id" IN (SELECT "users_ids"."id" FROM "users_ids")
),
offers_reviewed_by_id_attributes_filter AS 
( 
    SELECT "offers"."id" 
    FROM   "offers" 
    WHERE  "offers"."reviewed_by_id" IN (SELECT "users_ids"."id" FROM "users_ids")
),
offers_as_json_array AS 
( 
    SELECT Array_to_json(Array_agg(Row_to_json(tbl))) AS offers, 1 AS match
    FROM (
        SELECT * FROM "offers_created_by_id_attributes_filter"
        UNION 
        SELECT * FROM "offers_reviewed_by_id_attributes_filter"
    ) AS tbl
)
```

Instead of

``` sql
offers_attributes_filter AS 
( 
    SELECT "offers"."id" 
    FROM   "offers" 
    WHERE  "offers"."created_by_id" IN (SELECT "users_ids"."id" FROM "users_ids")
),
offers_attributes_filter AS 
( 
    SELECT "offers"."id" 
    FROM   "offers" 
    WHERE  "offers"."reviewed_by_id" IN (SELECT "users_ids"."id" FROM "users_ids")
),
offers_as_json_array AS 
( 
    SELECT Array_to_json(Array_agg(Row_to_json(offers_attributes_filter))) AS offers, 1 AS match 
    FROM "offers_attributes_filter"
)
```
## Other
- Not sure why relation was duplicated but removing call to duplicate fixes issue #19 
- Added note to readme mentioning timestamp formats generated by Postgres 9.2 & 9.3 as it's not supported by many clients since I was getting invalid date errors in client side app with generated json, 9.4 fixes this http://www.postgresql.org/docs/9.4/static/release-9-4.html
- Added `COALESCE` to return [] instead of null to fix #22
- Added check to see if Postgres 9.3 or higher is in use and if so use json_agg instead to implement request #10 but is using a protected method from postgres adapter which isn't the best
- Removed unused `_relation_to_json_array_arel` function and inlined json functions calls which made code more readable and removed a few functions, not sure if there is a reason to wrap each part in an arel node
- Added tests for issue #21 but haven't spent time fixing as our app no longer uses the API endpoints where discovered this issue
- **Deprecated change** - changed sql computed properties on serializers to be instance methods. Not sure if there was a reason for it being class methods, but if they're instance methods it means they have access to current_user alias is available which is more straight forward.
## Thanks

After getting this working for our app it has made a big difference to the performance of our app and are grateful for the idea and work put in.
