### PR TITLE
Test against rails 4.2 / ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 rvm:
 - 2.0.0
 - 2.1.8
+- 2.2.4
 
 gemfile:
   - gemfiles/Gemfile.activerecord-4.0.x
   - gemfiles/Gemfile.activerecord-4.1.x
+  - gemfiles/Gemfile.activerecord-4.2.x
 
 env: DATABASE_URL=postgres://postgres@localhost/postgres_ext_test
 

--- a/Rakefile
+++ b/Rakefile
@@ -111,8 +111,8 @@ end
 namespace :test do
   desc 'Test against all supported ActiveRecord versions'
   task :all do
-    # Currently only supports Active Record v4.0
-    %w(4.0.x).each do |version|
+    # Currently only supports Active Record v4.0-v4.2
+    %w(4.2.x).each do |version|
       sh "BUNDLE_GEMFILE='gemfiles/Gemfile.activerecord-#{version}' bundle install --quiet"
       sh "BUNDLE_GEMFILE='gemfiles/Gemfile.activerecord-#{version}' bundle exec rake test"
     end

--- a/gemfiles/Gemfile.activerecord-4.2.x
+++ b/gemfiles/Gemfile.activerecord-4.2.x
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec :path => '..'
+
+gem "activerecord", "~>4.2.0"

--- a/postgres_ext-serializers.gemspec
+++ b/postgres_ext-serializers.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   if RUBY_PLATFORM =~ /java/
     spec.add_development_dependency 'activerecord-jdbcpostgresql-adapter', '1.3.0.beta2'
   else
-    spec.add_development_dependency 'pg', '~> 0.13.2'
+    spec.add_development_dependency 'pg', '~> 0.15'
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,10 @@ require 'bourne'
 require 'database_cleaner'
 require 'postgres_ext/serializers'
 unless ENV['CI'] || RUBY_PLATFORM =~ /java/
-  require 'byebug'
+  begin
+    require 'byebug'
+  rescue LoadError
+  end
 end
 
 require 'dotenv'


### PR DESCRIPTION
This adds rails 4.2 and ruby 2.2 to the test matrix and suppresses errors if byebug is missing.

In order to be compatible with rails 4.2, the minimum pg gem version is raised to 0.15.