### PR TITLE
Fix custom embed keys

### DIFF
--- a/lib/postgres_ext/serializers/active_model/array_serializer.rb
+++ b/lib/postgres_ext/serializers/active_model/array_serializer.rb
@@ -117,7 +117,7 @@ module PostgresExt::Serializers::ActiveModel
             end
             association_sql_tables << _process_has_many_relation(association.key, association.embed_key, association_reflection, relation_query, ids_table_arel)
           elsif klass.column_names.include?(fkey) && !attributes.include?(fkey.to_sym)
-            relation_query = relation_query.select(relation_query_arel[fkey])
+            relation_query = relation_query.select(relation_query_arel[fkey].as(association.key.to_s))
           end
         end
       end

--- a/lib/postgres_ext/serializers/active_model/array_serializer.rb
+++ b/lib/postgres_ext/serializers/active_model/array_serializer.rb
@@ -115,7 +115,7 @@ module PostgresExt::Serializers::ActiveModel
             unless @_ctes.find { |as| as.left == ids_table_name }
               @_ctes << _postgres_cte_as(ids_table_name, "(#{id_query.to_sql})")
             end
-            association_sql_tables << _process_has_many_relation(key, association_reflection, relation_query, ids_table_arel)
+            association_sql_tables << _process_has_many_relation(association.key, association.embed_key, association_reflection, relation_query, ids_table_arel)
           elsif klass.column_names.include?(fkey) && !attributes.include?(fkey.to_sym)
             relation_query = relation_query.select(relation_query_arel[fkey])
           end
@@ -146,14 +146,14 @@ module PostgresExt::Serializers::ActiveModel
       end
     end
 
-    def _process_has_many_relation(key, association_reflection, relation_query, ids_table_arel)
+    def _process_has_many_relation(key, embed_key, association_reflection, relation_query, ids_table_arel)
       association_class = association_reflection.klass
       association_arel_table = association_class.arel_table
       association_query = association_class.group association_arel_table[association_reflection.foreign_key]
       association_query = association_query.select(association_arel_table[association_reflection.foreign_key])
-      id_column_name = "#{key.to_s.singularize}_ids"
+      id_column_name = key.to_s
       cte_name = "#{id_column_name}_by_#{relation_query.table_name}"
-      association_query = association_query.select(_array_agg(association_arel_table[:id], id_column_name))
+      association_query = association_query.select(_array_agg(association_arel_table[embed_key.to_sym], id_column_name))
       association_query = association_query.having(association_arel_table[association_reflection.foreign_key].in(ids_table_arel.project(ids_table_arel[:id])))
       @_ctes << _postgres_cte_as(cte_name, "(#{association_query.to_sql})")
       { table: cte_name, ids_column: id_column_name, foreign_key: association_reflection.foreign_key }
@@ -185,7 +185,7 @@ module PostgresExt::Serializers::ActiveModel
     end
 
     def _coalesce_arrays(column, aliaz = nil)
-      _postgres_function_node 'coalesce', [column, Arel.sql("'{}'::int[]")], aliaz
+      _postgres_function_node 'COALESCE', [column, Arel.sql("'{}'")], aliaz
     end
 
     def _results_table_arel

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -20,6 +20,22 @@ describe 'ArraySerializer patch' do
     end
   end
 
+  context 'custom key and embed_key' do
+    let(:relation)   { Note.all }
+    let(:controller) { NotesController.new }
+    let(:options)    { { each_serializer: CustomKeysNoteSerializer } }
+
+    before do
+      @note = Note.create content: 'Test', name: 'Title'
+      @tag = Tag.create name: 'My tag', note: @note
+    end
+
+    it 'generates the proper json output' do
+      json_expected = %{{"notes":[{"id":#{@note.id},"name":"Title","tag_names":["#{@tag.name}"]}],"tags":[{"id":#{@tag.id},"name":"My tag","note_id":#{@note.id}}]}}
+      json_data.must_equal json_expected
+    end
+  end
+
   context 'computed value methods' do
     let(:relation)   { Person.all }
     let(:controller) { PeopleController.new }

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -31,7 +31,7 @@ describe 'ArraySerializer patch' do
     end
 
     it 'generates the proper json output' do
-      json_expected = %{{"notes":[{"id":#{@note.id},"name":"Title","tag_names":["#{@tag.name}"]}],"tags":[{"id":#{@tag.id},"name":"My tag","note_id":#{@note.id}}]}}
+      json_expected = %{{"notes":[{"id":#{@note.id},"name":"Title","tag_names":["#{@tag.name}"]}],"tags":[{"id":#{@tag.id},"name":"My tag","tagged_note_id":#{@note.id}}]}}
       json_data.must_equal json_expected
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,6 +57,12 @@ class ShortTagSerializer < ActiveModel::Serializer
   attributes :id, :name
 end
 
+class CustomKeyTagSerializer < ActiveModel::Serializer
+  attributes :id, :name
+  embed :ids
+  has_one :note, key: :tagged_note_id
+end
+
 class OtherNoteSerializer < ActiveModel::Serializer
   attributes :id, :name
   has_many   :tags, serializer: ShortTagSerializer, embed: :ids, include: true
@@ -64,7 +70,7 @@ end
 
 class CustomKeysNoteSerializer < ActiveModel::Serializer
   attributes :id, :name
-  has_many   :tags, embed: :ids, include: true, key: :tag_names, embed_key: :name
+  has_many   :tags, serializer: CustomKeyTagSerializer, embed: :ids, include: true, key: :tag_names, embed_key: :name
 end
 
 class Tag < ActiveRecord::Base

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,6 +62,11 @@ class OtherNoteSerializer < ActiveModel::Serializer
   has_many   :tags, serializer: ShortTagSerializer, embed: :ids, include: true
 end
 
+class CustomKeysNoteSerializer < ActiveModel::Serializer
+  attributes :id, :name
+  has_many   :tags, embed: :ids, include: true, key: :tag_names, embed_key: :name
+end
+
 class Tag < ActiveRecord::Base
   belongs_to :note
 end


### PR DESCRIPTION
This adds support for the `:key` and `:embed_key` options for `has_many` associations in serializers and for the `:key` option of `has_one` associations.

There's currently no support for `:embed_key` on `has_one` associations, because it would require lookups on the foreign table of the association.

There's also a fix for coalesce on arrays that removes the restriction on integer keys which is required for `:embed_key` and to support non-integer primary keys, like UUIDs. The type specification in `COALESCE` is not needed, because it automatically casts the `NULL` replacement value to the type of the source expression.