### PR TITLE
Match original AMS root keys and allow override

### DIFF
--- a/test/sideloading_test.rb
+++ b/test/sideloading_test.rb
@@ -55,7 +55,7 @@ describe 'ArraySerializer patch' do
 
   context 'root relation has belongs_to association' do
     let(:relation)   { Tag.all }
-    let(:controller) { TagController.new }
+    let(:controller) { TagsController.new }
     let(:options)    { { each_serializer: TagWithNoteSerializer } }
 
     before do
@@ -78,13 +78,13 @@ describe 'ArraySerializer patch' do
 
   context 'relation has multiple associates to the same table' do
     let(:relation)   { User.order(:id) }
-    let(:controller) { UserController.new }
+    let(:controller) { UsersController.new }
 
     before do
       reviewer = User.create name: 'Peter'
       user = User.create name: 'John'
       offer = Offer.create created_by: user, reviewed_by: reviewer
-      @json_expected = "{\"users\":[{\"id\":#{reviewer.id},\"name\":\"Peter\",\"offer_ids\":[],\"reviewed_offer_ids\":[#{offer.id}]}, \n {\"id\":#{user.id},\"name\":\"John\",\"offer_ids\":[#{offer.id}],\"reviewed_offer_ids\":[]}],\"offers\":[{\"id\":#{offer.id}}]}"
+      @json_expected = "{\"users\":[{\"id\":#{reviewer.id},\"name\":\"Peter\",\"offer_ids\":[],\"reviewed_offer_ids\":[#{offer.id}]}, \n {\"id\":#{user.id},\"name\":\"John\",\"offer_ids\":[#{offer.id}],\"reviewed_offer_ids\":[]}],\"offers\":[{\"id\":#{offer.id}}],\"reviewed_offers\":[{\"id\":#{offer.id}}]}"
     end
 
     it 'generates the proper json output for the serializer' do
@@ -101,7 +101,7 @@ describe 'ArraySerializer patch' do
 
   context 'empty data should return empty array not null' do
     let(:relation)   { Tag.all }
-    let(:controller) { TagController.new }
+    let(:controller) { TagsController.new }
     let(:options)    { { each_serializer: TagWithNoteSerializer } }
 
     before do
@@ -122,7 +122,7 @@ describe 'ArraySerializer patch' do
 
   context 'nested filtering support' do
     let(:relation)   { Tag.where(note: { name: 'Title' }) }
-    let(:controller) { TagController.new }
+    let(:controller) { TagsController.new }
 
     before do
       note = Note.create content: 'Test', name: 'Title'
@@ -146,20 +146,20 @@ describe 'ArraySerializer patch' do
 
   context 'support for include_[attrbute]' do
     let(:relation)   { User.all }
-    let(:controller) { UserController.new }
+    let(:controller) { UsersController.new }
     let(:options)    { { each_serializer: UserSerializer } }
     before           { @user = User.create name: 'John', mobile: "51111111" }
 
     it 'generates json for serializer when include_[attribute]? is true' do
       address = Address.create district_name: "mumbai", user_id: @user.id
-      json_expected = "{\"users\":[{\"id\":#{@user.id},\"name\":\"John\",\"mobile\":\"51111111\",\"offer_ids\":[],\"reviewed_offer_ids\":[]}],\"offers\":[],\"addresses\":[{\"id\":#{address.id},\"district_name\":\"mumbai\"}]}"
+      json_expected = "{\"users\":[{\"id\":#{@user.id},\"name\":\"John\",\"mobile\":\"51111111\",\"offer_ids\":[],\"reviewed_offer_ids\":[]}],\"offers\":[],\"reviewed_offers\":[],\"addresses\":[{\"id\":#{address.id},\"district_name\":\"mumbai\"}]}"
 
       controller.stubs(:current_user).returns({ permission_id: 1 })
       json_data.must_equal json_expected
     end
 
     it 'generates json for serializer when include_[attribute]? is false' do
-      json_output = "{\"users\":[{\"id\":#{@user.id},\"name\":\"John\",\"offer_ids\":[],\"reviewed_offer_ids\":[]}],\"offers\":[]}"
+      json_output = "{\"users\":[{\"id\":#{@user.id},\"name\":\"John\",\"offer_ids\":[],\"reviewed_offer_ids\":[]}],\"offers\":[],\"reviewed_offers\":[]}"
       json_data.must_equal json_output
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,11 @@ require 'active_record'
 require 'minitest/autorun'
 require 'bourne'
 require 'database_cleaner'
-require 'postgres_ext/serializers'
+if ENV['TEST_UNPATCHED_AMS']
+  require 'active_model_serializers'
+else
+  require 'postgres_ext/serializers'
+end
 unless ENV['CI'] || RUBY_PLATFORM =~ /java/
   begin
     require 'byebug'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -81,7 +81,7 @@ class Tag < ActiveRecord::Base
   belongs_to :note
 end
 
-class TagController < TestController; end
+class TagsController < TestController; end
 
 class TagSerializer < ActiveModel::Serializer
   attributes :id, :name
@@ -110,7 +110,7 @@ class Offer < ActiveRecord::Base
   belongs_to :reviewed_by, class_name: 'User', inverse_of: :reviewed_offers
 end
 
-class UserController < TestController; end
+class UsersController < TestController; end
 class AddressController < TestController; end
 
 class OfferSerializer < ActiveModel::Serializer


### PR DESCRIPTION
Without this change, postgres_ext-seralizers root keys are based on table names which in many cases does not match the root keys generated by the original AMS array serializer (e.g. for namespaced models).

This has the unfortunate side effect of causing duplicate sideloaded data if circular associations are named differently due to root key customization, but it is required for clients to find the records by their default convention.

If you need to keep the old root key names or want to customize the root key, you can now specify the `:root` option to `render` just like with the original AMS array serializer.

Also fixed some bad controller naming in the tests and added support for testing against the unpatched AMS array serialized by setting the `TEST_UNPATCHED_AMS` environment variable before running tests. This is useful for comparing behavior between the two implementations.