### PR TITLE
Relax requirement for postgres_ext to include 3.x

### DIFF
--- a/postgres_ext-serializers.gemspec
+++ b/postgres_ext-serializers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency     'postgres_ext', '~> 2.1'
+  spec.add_runtime_dependency     'postgres_ext', '>= 2.1', '< 4'
   spec.add_runtime_dependency     'active_model_serializers', '~> 0.8.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
Tested with postgres_ext 3.0.0.