### PR TITLE
Don't ignore arel bind values in filter query

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -79,6 +79,7 @@ namespace :db do
     ActiveRecord::Base.connection.create_table :tags, force: true do |t|
       t.integer  "note_id"
       t.string   "name"
+      t.boolean  "popular"
       t.datetime "created_at"
       t.datetime "updated_at"
     end

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -54,4 +54,25 @@ describe 'ArraySerializer patch' do
       json_data.must_equal json_expected
     end
   end
+
+  context 'merging bind values' do
+    let(:relation)   { Note.joins(:popular_tags).where(name: 'Title') }
+    let(:controller) { NotesController.new }
+    let(:options)    { }
+
+    before do
+      @note = Note.create content: 'Test', name: 'Title'
+      @tag = Tag.create name: 'My tag', note: @note, popular: true
+    end
+
+    it 'generates the proper json output' do
+      json_expected = %{{"notes":[{"id":#{@note.id},"content":"Test","name":"Title","tag_ids":[#{@tag.id}]}],"tags":[{"id":#{@tag.id},"name":"My tag","note_id":#{@note.id}}]}}
+      begin
+        $break = true
+        json_data.must_equal json_expected
+      ensure
+        $break = false
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,6 +49,7 @@ class Note < ActiveRecord::Base
   has_many :tags
   has_many :sorted_tags
   has_many :custom_sorted_tags, lambda { order(:name) }, class_name: 'Tag'
+  has_many :popular_tags, lambda { where(popular: true) }, class_name: 'Tag'
 end
 
 class NotesController < TestController; end


### PR DESCRIPTION
This fixes missing bind values when conditions are on the arel select manager, for example join conditions. This is only used for AR 4.1+ because in AR 4.0 the `arel` has no `bind_values`.

It's possible that an additional fix is required for AR 4.0 if it does not store all bind values in `relation.bind_values`, we could probably add a test to check this case on all AR versions.

**TODO:**

- [x] Add a test that exercises this code.