### PR TITLE
Fix embedding has_many with ordered scope

### DIFF
--- a/test/sideloading_test.rb
+++ b/test/sideloading_test.rb
@@ -163,4 +163,52 @@ describe 'ArraySerializer patch' do
       json_data.must_equal json_output
     end
   end
+
+  context 'respects order in default scope of has_many association' do
+    let(:relation)   { Note.all }
+    let(:controller) { NotesController.new }
+    let(:options)    { { each_serializer: SortedTagsNoteSerializer } }
+
+    before do
+      note = Note.create name: 'test', content: 'dummy content'
+
+      tag2 = Tag.create name: 'tag 2', note_id: note.id
+      tag1 = Tag.create name: 'tag 1', note_id: note.id
+      tag3 = Tag.create name: 'tag 3', note_id: note.id
+      @json_expected = "{\"notes\":[{\"id\":#{note.id},\"sorted_tag_ids\":[#{tag1.id},#{tag2.id},#{tag3.id}]}],\"sorted_tags\":[{\"id\":#{tag1.id},\"name\":\"tag 1\"}, \n {\"id\":#{tag2.id},\"name\":\"tag 2\"}, \n {\"id\":#{tag3.id},\"name\":\"tag 3\"}]}"
+    end
+
+    it 'generates json output with correctly sorted tag ids and tags' do
+      $break = true
+      begin
+        json_data.must_equal @json_expected
+      ensure
+        $break = false
+      end
+    end
+  end
+
+  context 'respects order in custom scope of has_many association' do
+    let(:relation)   { Note.all }
+    let(:controller) { NotesController.new }
+    let(:options)    { { each_serializer: CustomSortedTagsNoteSerializer } }
+
+    before do
+      note = Note.create name: 'test', content: 'dummy content'
+
+      tag2 = Tag.create name: 'tag 2', note_id: note.id
+      tag1 = Tag.create name: 'tag 1', note_id: note.id
+      tag3 = Tag.create name: 'tag 3', note_id: note.id
+      @json_expected = "{\"notes\":[{\"id\":#{note.id},\"custom_sorted_tag_ids\":[#{tag1.id},#{tag2.id},#{tag3.id}]}],\"custom_sorted_tags\":[{\"id\":#{tag1.id},\"name\":\"tag 1\"}, \n {\"id\":#{tag2.id},\"name\":\"tag 2\"}, \n {\"id\":#{tag3.id},\"name\":\"tag 3\"}]}"
+    end
+
+    it 'generates json output with correctly sorted tag ids and tags' do
+      $break = true
+      begin
+        json_data.must_equal @json_expected
+      ensure
+        $break = false
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,6 +47,8 @@ end
 
 class Note < ActiveRecord::Base
   has_many :tags
+  has_many :sorted_tags
+  has_many :custom_sorted_tags, lambda { order(:name) }, class_name: 'Tag'
 end
 
 class NotesController < TestController; end
@@ -58,6 +60,10 @@ class NoteSerializer < ActiveModel::Serializer
 end
 
 class ShortTagSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end
+
+class SortedTagSerializer < ActiveModel::Serializer
   attributes :id, :name
 end
 
@@ -77,8 +83,25 @@ class CustomKeysNoteSerializer < ActiveModel::Serializer
   has_many   :tags, serializer: CustomKeyTagSerializer, embed: :ids, include: true, key: :tag_names, embed_key: :name
 end
 
+class SortedTagsNoteSerializer < ActiveModel::Serializer
+  attributes :id
+  has_many   :sorted_tags
+  embed      :ids, include: true
+end
+
+class CustomSortedTagsNoteSerializer < ActiveModel::Serializer
+  attributes :id
+  has_many   :custom_sorted_tags, serializer: ShortTagSerializer
+  embed      :ids, include: true
+end
+
 class Tag < ActiveRecord::Base
   belongs_to :note
+end
+
+class SortedTag < Tag
+  belongs_to :note
+  default_scope { order(:name) }
 end
 
 class TagsController < TestController; end


### PR DESCRIPTION
Previously this would break, because the `ORDER BY` did not match the generated `GROUP BY` clause.

This change moves the `ORDER BY` clause into the `array_agg` aggregate function, keeping the correct order of ids.

There doesn't seem to be a nice way in Arel to include an `ORDER BY` into a named function node, so a hack is used by first building a select node, stripping the `SELECT` keyword from the generated SQL and then passing it as a literal.

**TODO:**

- [x] Add a test that exercises this code (add default scope to a sideloaded association's model).
- [x] Fix compatibility with activerecord 4.0
- [x] Add support for custom scope in has_many (`has_many :tags, -> { order(:name) }`)