### PR TITLE
Add support for single record serialization

### DIFF
--- a/lib/postgres_ext/serializers.rb
+++ b/lib/postgres_ext/serializers.rb
@@ -10,3 +10,4 @@ require 'postgres_ext/serializers/active_model'
 require 'active_model_serializers'
 
 ActiveModel::ArraySerializer.send :prepend, PostgresExt::Serializers::ActiveModel::ArraySerializer
+ActiveModel::Serializer.send :prepend, PostgresExt::Serializers::ActiveModel::Serializer

--- a/lib/postgres_ext/serializers/active_model.rb
+++ b/lib/postgres_ext/serializers/active_model.rb
@@ -4,3 +4,4 @@ module PostgresExt::Serializers
 end
 
 require 'postgres_ext/serializers/active_model/array_serializer'
+require 'postgres_ext/serializers/active_model/serializer'

--- a/lib/postgres_ext/serializers/active_model/serializer.rb
+++ b/lib/postgres_ext/serializers/active_model/serializer.rb
@@ -1,0 +1,38 @@
+module PostgresExt::Serializers::ActiveModel
+  module Serializer
+    def self.prepended(base)
+      class << base
+        prepend ClassMethods
+      end
+    end
+
+    module ClassMethods
+      # Wrap ActiveModel::Serializer.build_json
+      # to send single records through ArraySerializer
+      # enabling database serialization.
+      def build_json(controller, resource, options)
+        serializer_instance = super
+        return serializer_instance unless serializer_instance
+
+        default_options = controller.send(:default_serializer_options) || {}
+        options = default_options.merge(options || {})
+
+        if ActiveRecord::Base === resource && options[:root] != false && serializer_instance.root_name != false
+          options[:root] ||= serializer_instance.root_name
+          options[:each_serializer] = serializer_instance.class
+          options[:single_record] = options.fetch(:single_record, true)
+          options.delete(:serializer) # Reset to default ArraySerializer.
+
+          # Wrap Record in a Relation.
+          klass = resource.class
+          primary_key = klass.primary_key
+          resource = klass.where(primary_key => resource.send(primary_key)).limit(1)
+
+          super(controller, resource, options)
+        else
+          serializer_instance
+        end
+      end
+    end
+  end
+end

--- a/test/sideloading_test.rb
+++ b/test/sideloading_test.rb
@@ -1,3 +1,4 @@
+require 'test_helper'
 
 describe 'ArraySerializer patch' do
   let(:json_data)  { ActiveModel::Serializer.build_json(controller, relation, options).to_json }


### PR DESCRIPTION
This will handle serialization of single records as used for example in show actions using the postres array serializer. To be able to do this, the record is wrapped in a relation using its primary key for lookup.

It's also possible to use this feature with a relation by passing the `root: 'singular_name'` and `single_record: true` options to `render` or the serializer, but you have to ensure that the relation only returns a single record, for example by using `.limit(1)`.

The single record serialization format does use a singular root key name for the main resource and does not wrap the object in an array:

Collection: `{"notes":[{"id":1,"tag_ids":[1]}],"tags":[...]}`
Single Record: `{"note":{"id":1,"tag_ids":[1]},"tags":[...]}`

The latter format is required by ember-data with the active model adapter when using `find('note', 1)`.

This PR does not add support for the `root: false` option (see #13). For single records a fallback to the regular serializer will be used when root is disabled.