### PR TITLE
Single record mode and root false tweaks

### DIFF
--- a/lib/postgres_ext/serializers/active_model/array_serializer.rb
+++ b/lib/postgres_ext/serializers/active_model/array_serializer.rb
@@ -6,7 +6,8 @@ module PostgresExt::Serializers::ActiveModel
 
     module IncludeMethods
       def to_json(*)
-        if ActiveRecord::Relation === object
+        root = @options.fetch(:root, self.class.root)
+        if ActiveRecord::Relation === object && root != false
           _postgres_serializable_array
         else
           super

--- a/lib/postgres_ext/serializers/active_model/array_serializer.rb
+++ b/lib/postgres_ext/serializers/active_model/array_serializer.rb
@@ -37,9 +37,10 @@ module PostgresExt::Serializers::ActiveModel
 
     def _postgres_serializable_array
       _reset_internal_state!
-      _include_relation_in_root(object, serializer: @options[:each_serializer], root: @options[:root])
+      root_key = _include_relation_in_root(object, serializer: @options[:each_serializer], root: @options[:root], single_record: @options[:single_record])
 
-      jsons_select_manager = _results_table_arel(@options[:single_record] ? @options[:root] : nil)
+      singular_resource_key = root_key if @options[:single_record]
+      jsons_select_manager = _results_table_arel(singular_resource_key)
       jsons_select_manager.with @_ctes
 
       @_connection.select_value _to_sql(jsons_select_manager)
@@ -61,7 +62,9 @@ module PostgresExt::Serializers::ActiveModel
       end
 
       _serializer = serializer_class.new klass.new, options
-      root_key = local_options.fetch(:root, _serializer.root_name.to_s.pluralize).to_s
+      root_key = local_options[:root].to_s if local_options[:root]
+      root_key ||=  _serializer.root_name.to_s if local_options[:single_record]
+      root_key ||=  _serializer.root_name.to_s.pluralize
       @_embedded << root_key
 
       attributes = serializer_class._attributes.select do |key, value|
@@ -171,6 +174,8 @@ module PostgresExt::Serializers::ActiveModel
             constraining_table_param, serializer: association.target_serializer, belongs_to: belongs_to, root: association_class.options[:root])
         end
       end
+
+      root_key
     end
 
     def _process_has_many_relation(key, embed_key, association_reflection, relation_query, ids_table_arel)

--- a/lib/postgres_ext/serializers/active_model/array_serializer.rb
+++ b/lib/postgres_ext/serializers/active_model/array_serializer.rb
@@ -17,6 +17,15 @@ module PostgresExt::Serializers::ActiveModel
 
     private
 
+    # Provide single_record behavior for original ArraySerializer.
+    def _serializable_array
+      if @options[:single_record]
+        super.first
+      else
+        super
+      end
+    end
+
     def _reset_internal_state!
       @_ctes = []
       @_results_tables = {}

--- a/lib/postgres_ext/serializers/active_model/serializer.rb
+++ b/lib/postgres_ext/serializers/active_model/serializer.rb
@@ -28,10 +28,13 @@ module PostgresExt::Serializers::ActiveModel
           primary_key = klass.primary_key
           resource = klass.where(primary_key => resource.send(primary_key)).limit(1)
 
-          super(controller, resource, options)
-        else
-          serializer_instance
+          serializer_instance = super(controller, resource, options)
+        elsif ActiveRecord::Relation === resource && options[:single_record] && options[:root].nil? && serializer_instance.class.root.nil?
+          # Fix controller derived root key to be singular for single_record mode.
+          serializer_instance.options[:root] = controller.controller_name.singularize
         end
+
+        serializer_instance
       end
     end
   end

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -111,10 +111,10 @@ describe 'ArraySerializer patch' do
     end
   end
 
-  context 'force single record mode' do
+  context 'forcing single record mode' do
     let(:relation)   { Note.where(name: 'Title').limit(1) }
     let(:controller) { NotesController.new }
-    let(:options)    { { root: 'note', single_record: true } }
+    let(:options)    { { single_record: true } }
 
     before do
       @note = Note.create content: 'Test', name: 'Title'
@@ -123,6 +123,22 @@ describe 'ArraySerializer patch' do
 
     it 'generates the proper json output' do
       json_expected = %{{"note":{"id":#{@note.id},"content":"Test","name":"Title","tag_ids":[#{@tag.id}]},"tags":[{"id":#{@tag.id},"name":"My tag","note_id":#{@note.id}}]}}
+      json_data.must_equal json_expected
+    end
+  end
+
+  context 'forcing single record mode with custom root key' do
+    let(:relation)   { Note.where(name: 'Title').limit(1) }
+    let(:controller) { NotesController.new }
+    let(:options)    { { single_record: true, root: :foo } }
+
+    before do
+      @note = Note.create content: 'Test', name: 'Title'
+      @tag = Tag.create name: 'My tag', note: @note, popular: true
+    end
+
+    it 'generates the proper json output' do
+      json_expected = %{{"foo":{"id":#{@note.id},"content":"Test","name":"Title","tag_ids":[#{@tag.id}]},"tags":[{"id":#{@tag.id},"name":"My tag","note_id":#{@note.id}}]}}
       json_data.must_equal json_expected
     end
   end


### PR DESCRIPTION
* Fallback to ruby serializer for `root: false` option (until we add support for it)
* Implement single_record for ruby array serializer (to unify behavior when mixing ruby/db serializers)
* Auto-singularize root key in single record mode (specifying `root: 'singular_name'` is now optional)

There currently are no tests for the fallback and single_record behavior, but we should add it after #53 is implemented.
