### PR TITLE
Add pry for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ bin/
 gemfiles/*.lock
 *.swp
 *.un~
+.pryrc

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in postgres_ext-serializers.gemspec
 gemspec
 
-unless ENV['CI'] || RUBY_PLATFORM =~ /java/
-  gem 'byebug'
+unless ENV['CI']
   gem 'm'
+  gem 'pry'
+  gem 'pry-highlight'
+  gem 'pry-byebug', platforms: [:mri]
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,10 +7,13 @@ if ENV['TEST_UNPATCHED_AMS']
 else
   require 'postgres_ext/serializers'
 end
-unless ENV['CI'] || RUBY_PLATFORM =~ /java/
+unless ENV['CI']
   begin
-    require 'byebug'
-  rescue LoadError
+    require 'pry'
+    require 'pry-highlight'
+    require 'pry-byebug' unless RUBY_PLATFORM =~ /java/
+  rescue LoadError => e
+    STDERR.puts "test/test_helper.rb:#{__LINE__}: #{e.message}"
   end
 end
 


### PR DESCRIPTION
This adds the following gems in development:
* pry: to break into and inspect the code at runtime
* pry-highlight: pretty print json inside pry
* pry-byebug: byebug integration for pry

A useful addition to this is the following `.pryrc` which enables ActiveRecord query logging inside pry:

```ruby
# Log queries to STDOUT during pry sessions.
Pry.config.hooks.add_hook(:when_started, :log_ar_queries) do
  if defined?(Rails)
    $pry_ar_logger = Logger.new(STDOUT) unless defined? $pry_ar_logger
  end
end
Pry.config.hooks.add_hook(:before_session, :log_ar_queries) do
  if defined?(Rails)
    $last_ar_logger = ActiveRecord::Base.logger
    ActiveRecord::Base.logger = $pry_ar_logger
  end
end
Pry.config.hooks.add_hook(:after_session, :log_ar_queries) do
  if defined?(Rails)
    ActiveRecord::Base.logger = $last_ar_logger
  end
end
```

The `.pryrc` should be user configurable, so I did not add it to version control.