### PR TITLE
Refacor array serializer to allow access to sql

### DIFF
--- a/test/sideloading_test.rb
+++ b/test/sideloading_test.rb
@@ -1,7 +1,8 @@
 require 'test_helper'
 
 describe 'ArraySerializer patch' do
-  let(:json_data)  { ActiveModel::Serializer.build_json(controller, relation, options).to_json }
+  let(:serializer) { ActiveModel::Serializer.build_json(controller, relation, options) }
+  let(:json_data)  { serializer.to_json }
   let(:options)    { }
 
   context 'no where clause on root relation' do


### PR DESCRIPTION
This PR adds access to the generated `WITH` query through the private method `_serializer_sql` to help with debugging queries.

I was temped to use a public `to_sql` method, but kept it private to keep the public interface between the patched and unpatched `ArraySerializer` the same.

I've also refactored some internals and fixed some recently added methods to be sorted in calling order.