### PR TITLE
Improve choices in rake setup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,16 +22,20 @@ task :setup do
   db_password = STDIN.gets.chomp
   print 'Enter your database server: [localhost] '
   db_server = STDIN.gets.chomp
+  print 'Enter your database port: [5432] '
+  db_port = STDIN.gets.chomp
 
   db_name = 'postgres_ext_test' if db_name.empty?
   db_password = ":#{db_password}" unless db_password.empty?
   db_server = 'localhost' if db_server.empty?
 
   db_server = "@#{db_server}" unless db_user.empty?
+  db_server = "#{db_server}:#{db_port}"
 
   env_path = File.expand_path('./.env')
   File.open(env_path, 'w') do |file|
     file.puts "DATABASE_NAME=#{db_name}"
+    file.puts "DATABASE_PORT=#{db_port}"
     file.puts "DATABASE_URL=\"postgres://#{db_user}#{db_password}#{db_server}/#{db_name}\""
   end
 
@@ -48,15 +52,15 @@ namespace :db do
   end
 
   task :psql => :load_db_settings do
-    exec "psql #{ENV['DATABASE_NAME']}"
+    exec "psql -p #{ENV['DATABASE_PORT']} #{ENV['DATABASE_NAME']}"
   end
 
   task :drop => :load_db_settings do
-    %x{ dropdb #{ENV['DATABASE_NAME']} }
+    %x{ dropdb -p #{ENV['DATABASE_PORT']} #{ENV['DATABASE_NAME']} }
   end
 
   task :create => :load_db_settings do
-    %x{ createdb #{ENV['DATABASE_NAME']} }
+    %x{ createdb -p #{ENV['DATABASE_PORT']} #{ENV['DATABASE_NAME']} }
   end
 
   task :migrate => :load_db_settings do

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'uri'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
@@ -26,7 +27,7 @@ task :setup do
   db_port = STDIN.gets.chomp
 
   db_name = 'postgres_ext_test' if db_name.empty?
-  db_password = ":#{db_password}" unless db_password.empty?
+  db_password = ":#{URI.escape(db_password)}" unless db_password.empty?
   db_server = 'localhost' if db_server.empty?
 
   db_server = "@#{db_server}" unless db_user.empty?

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ task :setup do
   if File.exist?('.env')
     puts 'This will overwrite your existing .env file'
   end
-  print 'Enter your database name: [postgres_ext_serializers_test] '
+  print 'Enter your database name: [postgres_ext_test] '
   db_name = STDIN.gets.chomp
   print 'Enter your database user: [] '
   db_user = STDIN.gets.chomp


### PR DESCRIPTION
This PR bundles three minor improvements, all around Postgres connection parameters:

- You can give a postgres port, in case you have multiple versions of postgres installed.
- We urlencode the password in your connection URL, in case it has special characters.
- We print the correct default database name (`postgres_ext_serializers_test` vs `postgres_ext_test`).

Btw I'd be happy to take over maintainership of this gem if you have abandoned it. (I realize I probably need to renovate `postgres_ext` too or switch this gem to `ctes_in_my_pg`.) I've taken the approach of generating JSON in Postgres on a bunch of projects, but with manual SQL, and having this gem would be a huge improvement. Let me know what you think!